### PR TITLE
DOPS-415 GH workflow to build the dev-portal using docusaurus

### DIFF
--- a/.github/workflows/publish-to-ghpages.yaml
+++ b/.github/workflows/publish-to-ghpages.yaml
@@ -1,0 +1,37 @@
+name: Publish to GH Pages
+
+on:
+  workflow_dispatch:
+  # push:
+  #   branches: 
+  #     - main
+
+jobs:
+  publish_to_ghpages:
+    name: Publish to GH Pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build the Portal and generate the API docs
+        run: yarn build
+
+      - name: Deploy to GH Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          publish_branch: gh-pages
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
* Automatic execution on PUSH deactivated to avoid remove existing content in `gh-pages` branch 
* Using only `build` script of `package.json` to trigger whole process.
* Using `peaceiris/actions-gh-pages@v3` recommended by Docusaurus to publish the generated content to `gh-pages` branch.