### PR TITLE
Add dark/light logo variations and media query

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center" width="100%">
-    <img src="https://developer.vocdoni.io/img/vocdoni_logotype_full_white.svg" />
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://developer.vocdoni.io/img/vocdoni_logotype_full_blank.svg" />
+      <source media="(prefers-color-scheme: light)" srcset="https://developer.vocdoni.io/img/vocdoni_logotype_full_white.svg" />
+      <img alt="Vocdoni logo" src="https://developer.vocdoni.io/img/vocdoni_logotype_full_white.svg" />
+  </picture>
 </p>
 
 <p align="center" width="100%">
@@ -42,7 +46,7 @@
 
 # developer-portal
 
-This repository hosts the Vocdoni developer portal, the source-of-truth of technical documentation for all of the software under the Vocdoni umbrella. 
+This repository hosts the Vocdoni developer portal, the source-of-truth of technical documentation for all of the software under the Vocdoni umbrella.
 It is created with [Docusaurus](https://docusaurus.io/) and is hosted at https://developer.vocdoni.io
 
 ### Table of Contents
@@ -88,11 +92,11 @@ The Vocdoni API documentation is sourced from the `swaggers` folder. If you modi
 yarn run re-gen
 ```
 
-Note that this docs generation step is already performed as part of `yarn start` or `yarn build`. 
+Note that this docs generation step is already performed as part of `yarn start` or `yarn build`.
 
 ### Generate the SDK documentation
 
-If you want to generate the SDK documentation for yourself, you can do so from inside the `docs` directory in the `vocdoni-sdk` project. 
+If you want to generate the SDK documentation for yourself, you can do so from inside the `docs` directory in the `vocdoni-sdk` project.
 
 ~~~bash
 yarn
@@ -127,14 +131,14 @@ yarn crowdin:download
 
 This will download translation files to the `i18n/` folder. To test them use `yarn start -- --locale es`.
 
-See these issues [1](https://community.crowdin.com/t/exclude-single-line-on-markdown-headers/2897), 
-[2](https://community.crowdin.com/t/broken-mdx-components-on-download/2912) to understand why the `pre`/`post` scripts 
-on crowdin download and upload. 
+See these issues [1](https://community.crowdin.com/t/exclude-single-line-on-markdown-headers/2897),
+[2](https://community.crowdin.com/t/broken-mdx-components-on-download/2912) to understand why the `pre`/`post` scripts
+on crowdin download and upload.
 
 
-## Contributing 
+## Contributing
 
-While we welcome contributions from the community, we do not track all of our issues on Github and we may not have the resources to onboard developers and review complex pull requests. That being said, there are multiple ways you can get involved with the project. 
+While we welcome contributions from the community, we do not track all of our issues on Github and we may not have the resources to onboard developers and review complex pull requests. That being said, there are multiple ways you can get involved with the project.
 
 Please review our [development guidelines](https://developer.vocdoni.io/development-guidelines).
 

--- a/docs/development-guidelines/readme-template.md
+++ b/docs/development-guidelines/readme-template.md
@@ -1,6 +1,6 @@
 # Readme Template
 
-Please use this template when creating readme files for new Vocdoni repositories. This is meant to serve as a guide, rather than a rigid rule; adapt it as necessary. Replace all the instances of `REPO_NAME` with the name of your repository, and fill-in the contents of every `\[bracketed\] item. If you add new sections, make sure to update the table of contents. 
+Please use this template when creating readme files for new Vocdoni repositories. This is meant to serve as a guide, rather than a rigid rule; adapt it as necessary. Replace all the instances of `REPO_NAME` with the name of your repository, and fill-in the contents of every `\[bracketed\] item. If you add new sections, make sure to update the table of contents.
 
 ***Make sure to replace the `REPO_NAME` placeholders in the repo-specific badge links***
 
@@ -11,8 +11,13 @@ Some features are displayed differently on the developer portal than they are wh
 ---
 
 <p align="center" width="100%">
-    <img src="https://developer.vocdoni.io/img/vocdoni_logotype_full_white.svg" />
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://developer.vocdoni.io/img/vocdoni_logotype_full_blank.svg" />
+      <source media="(prefers-color-scheme: light)" srcset="https://developer.vocdoni.io/img/vocdoni_logotype_full_white.svg" />
+      <img alt="Vocdoni logo" src="https://developer.vocdoni.io/img/vocdoni_logotype_full_white.svg" />
+  </picture>
 </p>
+
 
 <p align="center" width="100%">
     <a href="https://github.com/vocdoni/REPO_NAME/commits/main/"><img src="https://img.shields.io/github/commit-activity/m/vocdoni/REPO_NAME" /></a>
@@ -100,9 +105,9 @@ The best place to learn about using \[REPO_NAME\] is the [developer portal](http
 
 \[The code in this repo\] is WIP. Please beware that it can be broken at any time if the release is `alpha` or `beta`. We encourage you to review this repository and the developer portal for any changes.
 
-## Contributing 
+## Contributing
 
-While we welcome contributions from the community, we do not track all of our issues on Github and we may not have the resources to onboard developers and review complex pull requests. That being said, there are multiple ways you can get involved with the project. 
+While we welcome contributions from the community, we do not track all of our issues on Github and we may not have the resources to onboard developers and review complex pull requests. That being said, there are multiple ways you can get involved with the project.
 
 Please review our [development guidelines](https://developer.vocdoni.io/development-guidelines).
 


### PR DESCRIPTION
Changed the Vocdoni logos so we load different versions depending on the user's OS theme (dark/light).

This way, instead of loading only this image:
![imatge](https://github.com/vocdoni/developer-portal/assets/153305/2e61f200-095b-462d-99b7-138c0c54c4de)

We're loading different images based on the user's OS theme:
![imatge](https://github.com/vocdoni/developer-portal/assets/153305/f4dbedea-cf17-4774-9f1c-c1d2dacd9fae)
![imatge](https://github.com/vocdoni/developer-portal/assets/153305/ff472965-c75e-45e6-b0d2-ff350cb36349)
